### PR TITLE
Added import for throw to fix 'Observable.throw is not a function'

### DIFF
--- a/src/app/core/api.service.ts
+++ b/src/app/core/api.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http
 import { AuthService } from './../auth/auth.service';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/observable/throw';
 import { ENV } from './env.config';
 import { EventModel } from './models/event.model';
 import { RsvpModel } from './models/rsvp.model';


### PR DESCRIPTION
If you get an API error (500) like I am getting, you will get a console error saying: Observable.throw is not a function

As suggested by the following closed Rxjs issue, throw needs to be imported from 'rxjs/add/observable/throw'
https://github.com/ReactiveX/rxjs/issues/1866,